### PR TITLE
Fix daily extreme computation

### DIFF
--- a/data/Fissures/Fissure route/data_route/figures.py
+++ b/data/Fissures/Fissure route/data_route/figures.py
@@ -96,33 +96,20 @@ def create_fig_main(df, daily_stats, global_min, global_max, colors):
             daily_stats.at[idx, 'max'] = np.nan
             continue
 
-        # 4) MAX absolu valide
+        # 4) MAX et MIN absolus valides (ordre indifférent)
         max_val = None
+        min_val = None
         for v in sorted(interior['inch'].unique(), reverse=True):
             boundary = day_df[day_df['inch'] == v]
-            # on rejette si ce niveau est aussi à first_ts ou last_ts
             if not (boundary['timestamp'].eq(first_ts).any() or boundary['timestamp'].eq(last_ts).any()):
                 max_val = v
                 break
-        daily_stats.at[idx, 'max'] = max_val if max_val is not None else np.nan
-
-        # 5) MIN absolu valide après max
-        if pd.isna(max_val):
-            daily_stats.at[idx, 'min'] = np.nan
-            continue
-
-        max_ts = day_df.loc[day_df['inch'] == max_val, 'timestamp'].min()
-        aft = interior[interior['timestamp'] > max_ts]
-        if aft.empty:
-            daily_stats.at[idx, 'min'] = np.nan
-            continue
-
-        min_val = None
-        for v in sorted(aft['inch'].unique()):
+        for v in sorted(interior['inch'].unique()):
             boundary = day_df[day_df['inch'] == v]
             if not (boundary['timestamp'].eq(first_ts).any() or boundary['timestamp'].eq(last_ts).any()):
                 min_val = v
                 break
+        daily_stats.at[idx, 'max'] = max_val if max_val is not None else np.nan
         daily_stats.at[idx, 'min'] = min_val if min_val is not None else np.nan
 
     # Lignes horizontales pour min, max, mean, median de chaque jour + trace de ces stats

--- a/data/Fissures/Fissure route/data_route/stats_calculator.py
+++ b/data/Fissures/Fissure route/data_route/stats_calculator.py
@@ -181,9 +181,14 @@ def compute_confidence_intervals_hours(hours: np.ndarray,
 
 # ------------------------------------------------------- extrêmes journaliers
 def extract_extreme_hours(df: pd.DataFrame):
-    idx_max = df.groupby('day')['inch'].idxmax()
-    idx_min = df.groupby('day')['inch'].idxmin()
-    return df.loc[idx_max, 'hour'].to_numpy(), df.loc[idx_min, 'hour'].to_numpy()
+    """Heures (décimales) des max/min journaliers hors 00:00/24:00."""
+    from time_calculator import compute_daily_extrema_timestamps
+
+    ext = compute_daily_extrema_timestamps(df)
+    to_hours = lambda ts: ts.dt.hour + ts.dt.minute / 60 + ts.dt.second / 3600
+    h_max = to_hours(ext['time_max'])
+    h_min = to_hours(ext['time_min'])
+    return h_max.to_numpy(), h_min.to_numpy()
 
 
 def compute_extremes_stats(df: pd.DataFrame,

--- a/data/Fissures/Fissure route/data_route/time_calculator.py
+++ b/data/Fissures/Fissure route/data_route/time_calculator.py
@@ -68,15 +68,12 @@ def compute_daily_extrema_timestamps(df: pd.DataFrame) -> pd.DataFrame:
         if interior.empty:
             continue
 
+        # Max et min absolus sur les données restantes (ordre indifférent)
         val_max = interior["inch"].max()
         time_max = interior.loc[interior["inch"].idxmax(), "timestamp"]
 
-        aft = interior[interior["timestamp"] > time_max]
-        if aft.empty:
-            continue
-
-        val_min = aft["inch"].min()
-        time_min = aft.loc[aft["inch"].idxmin(), "timestamp"]
+        val_min = interior["inch"].min()
+        time_min = interior.loc[interior["inch"].idxmin(), "timestamp"]
 
         records.append({
             "day":      day,


### PR DESCRIPTION
## Summary
- fix daily extrema logic to handle min/max order
- update main figure logic for extrema
- use extrema timestamps when computing daily extreme hours

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6849c766d8cc8332a2e3cf358f748d55